### PR TITLE
Potential fix for code scanning alert no. 5: Database query built from user-controlled sources

### DIFF
--- a/server.js
+++ b/server.js
@@ -147,22 +147,19 @@ app.post('/api/search', (req, res) => {
 // Additional vulnerable endpoint for demonstration
 app.get('/api/monster/:id', (req, res) => {
     const { id } = req.params;
-    
-    /* 
-    ⚠️ ANOTHER SQL INJECTION VULNERABILITY ⚠️
-    Direct parameter insertion without validation
-    */
-    const vulnerableQuery = `SELECT * FROM monsters WHERE id = ${id}`;
-    
-    db.get(vulnerableQuery, (err, row) => {
+
+    // Secure: parameterized query to prevent SQL injection
+    const secureQuery = 'SELECT * FROM monsters WHERE id = ?';
+
+    db.get(secureQuery, [id], (err, row) => {
         if (err) {
             return res.status(500).json({ error: err.message });
         }
-        
+
         if (!row) {
             return res.status(404).json({ error: 'Monster not found' });
         }
-        
+
         res.json(row);
     });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/githubcustomers/mbianchidev-eficode-universe-2025/security/code-scanning/5](https://github.com/githubcustomers/mbianchidev-eficode-universe-2025/security/code-scanning/5)

To fix the vulnerability, parameterize the SQL query so that the user-supplied `id` value is not directly interpolated into the query string. SQLite's `sqlite3` Node.js library supports parameterization using placeholders (`?`) in the SQL string, with parameter values passed as an array or object in the second argument to `db.get`. 

Specifically:
- Change the query `SELECT * FROM monsters WHERE id = ${id}` to use a placeholder: `SELECT * FROM monsters WHERE id = ?`.
- Pass the `id` parameter as part of the parameter array (e.g., `[id]`) to the `db.get` function.
- For even stronger safety, you may optionally coerce `id` to an integer (if IDs are always integers) to prevent edge-case injection attempts via type confusion.

This change requires only the affected route handler (lines 148–168) to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
