### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,19 @@
     "start": "node server.js",
     "dev": "nodemon server.js"
   },
-  "keywords": ["zelda", "demo", "security", "vulnerabilities"],
+  "keywords": [
+    "zelda",
+    "demo",
+    "security",
+    "vulnerabilities"
+  ],
   "author": "GitHub Copilot",
   "license": "MIT",
   "dependencies": {
     "express": "^4.18.2",
     "sqlite3": "^5.1.6",
-    "body-parser": "^1.20.3"
+    "body-parser": "^1.20.3",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"


### PR DESCRIPTION
Potential fix for [https://github.com/githubcustomers/mbianchidev-eficode-universe-2025/security/code-scanning/7](https://github.com/githubcustomers/mbianchidev-eficode-universe-2025/security/code-scanning/7)

To fix this vulnerability, a rate-limiting middleware should be applied to the `/api/search` endpoint (and ideally to other routes performing database actions). The most robust, well-known package for this purpose in Express is `express-rate-limit`. The best way to fix it is as follows:

- Install `express-rate-limit`.
- Import `express-rate-limit` at the top of `server.js`.
- Create a limiter instance with an appropriate configuration (e.g., a reasonable number of requests per minute).
- Apply the limiter specifically to the `/api/search` route, either by using the middleware as the second argument to `app.post`, or via `app.use` for selected routes.
- Do not alter existing functionality—just add the middleware.

All changes are within `server.js`. Add the required import, limiter definition, and apply the middleware to the vulnerable route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
